### PR TITLE
Add the ability to remove coverage info from SecurityControlCoverage

### DIFF
--- a/lib/controls/objects/security_control_coverage.rb
+++ b/lib/controls/objects/security_control_coverage.rb
@@ -5,6 +5,20 @@ module Controls
     coerce :assessmentTimestamp, ->(value) { Time.at(value / 1000) if value }
     coerce :coverage, Controls::CoverageInformation
 
+    def without_coverage
+      Controls::SecurityControl.new(enabled: enabled, name: name)
+    end
+
+    def without_coverage!
+      coverage_keys = @_original_hash.keys.reject do |key|
+        %w[enabled name].include? key
+      end
+
+      coverage_keys.each do |key|
+        @_original_hash.delete(key)
+      end
+    end
+
     def to_s
       title
     end


### PR DESCRIPTION
- [x] `SecurityControlCoverage#without_coverage` - Converts to a `SecurityControl`.
- [x] `SecurityControlCoverage#without_coverage!` - Removes all coverage related key/value pairs.
